### PR TITLE
Fix typo in pin name (Socket_DIN41612-CaseB1-Male_64Pin-2rows.kicad_mod)

### DIFF
--- a/Socket_DIN41612-CaseB1-Male_64Pin-2rows.kicad_mod
+++ b/Socket_DIN41612-CaseB1-Male_64Pin-2rows.kicad_mod
@@ -69,7 +69,7 @@
   (pad 21a thru_hole circle (at -11.43 -1.27 180) (size 1.50114 1.50114) (drill 0.8001) (layers *.Cu *.Mask F.SilkS))
   (pad 22a thru_hole circle (at -13.97 -1.27 180) (size 1.50114 1.50114) (drill 0.8001) (layers *.Cu *.Mask F.SilkS))
   (pad 23a thru_hole circle (at -16.51 -1.27 180) (size 1.50114 1.50114) (drill 0.8001) (layers *.Cu *.Mask F.SilkS))
-  (pad 24 thru_hole circle (at -19.05 -1.27 180) (size 1.50114 1.50114) (drill 0.8001) (layers *.Cu *.Mask F.SilkS))
+  (pad 24a thru_hole circle (at -19.05 -1.27 180) (size 1.50114 1.50114) (drill 0.8001) (layers *.Cu *.Mask F.SilkS))
   (pad 25a thru_hole circle (at -21.59 -1.27 180) (size 1.50114 1.50114) (drill 0.8001) (layers *.Cu *.Mask F.SilkS))
   (pad 26a thru_hole circle (at -24.13 -1.27 180) (size 1.50114 1.50114) (drill 0.8001) (layers *.Cu *.Mask F.SilkS))
   (pad 27a thru_hole circle (at -26.67 -1.27 180) (size 1.50114 1.50114) (drill 0.8001) (layers *.Cu *.Mask F.SilkS))


### PR DESCRIPTION
Pin `24` should be `24a`.
